### PR TITLE
add user flags to qmake project

### DIFF
--- a/Build/Darwin/FaustLive.pro
+++ b/Build/Darwin/FaustLive.pro
@@ -63,6 +63,11 @@ QMAKE_INFO_PLIST = FaustLiveInfo.plist
 
 ####### INCLUDES PATHS && LIBS PATHS
 
+# Use user environment flags
+QMAKE_CXXFLAGS += $$(CXXFLAGS)
+QMAKE_CFLAGS += $$(CFLAGS)
+QMAKE_LFLAGS += $$(LDFLAGS)
+
 DEPENDPATH += $$FAUSTDIR/include/faust/gui
 INCLUDEPATH += .
 INCLUDEPATH += /opt/local/include

--- a/Build/Linux/FaustLive.pro
+++ b/Build/Linux/FaustLive.pro
@@ -51,6 +51,11 @@ QMAKE_INFO_PLIST = FaustLiveInfo.plist
 
 ####### INCLUDES PATHS && LIBS PATHS
 
+# Use user environment flags
+QMAKE_CXXFLAGS += $$(CXXFLAGS)
+QMAKE_CFLAGS += $$(CFLAGS)
+QMAKE_LFLAGS += $$(LDFLAGS)
+
 DEPENDPATH += $$FAUSTDIR/include/faust/gui
 INCLUDEPATH += .
 INCLUDEPATH += /opt/local/include

--- a/Build/MinGW32/FaustLive.pro
+++ b/Build/MinGW32/FaustLive.pro
@@ -48,6 +48,11 @@ QMAKE_INFO_PLIST = FaustLiveInfo.plist
 
 ####### INCLUDES PATHS && LIBS PATHS
 
+# Use user environment flags
+QMAKE_CXXFLAGS += $$(CXXFLAGS)
+QMAKE_CFLAGS += $$(CFLAGS)
+QMAKE_LFLAGS += $$(LDFLAGS)
+
 DEPENDPATH += $$FAUSTDIR/include/faust/gui
 INCLUDEPATH += .
 INCLUDEPATH += /opt/local/include	

--- a/Build/Windows/FaustLive.pro
+++ b/Build/Windows/FaustLive.pro
@@ -37,6 +37,11 @@ RESOURCES += ../../Resources/windows.qrc
 
 RC_FILE = FaustLive.rc
 
+# Use user environment flags
+QMAKE_CXXFLAGS += $$(CXXFLAGS)
+QMAKE_CFLAGS += $$(CFLAGS)
+QMAKE_LFLAGS += $$(LDFLAGS)
+
 ## VISUAL STUDIO PROJECT
 TEMPLATE = vcapp
 INCLUDEPATH += C:\Qt\Qt5.2.0\msvc\include


### PR DESCRIPTION
Add user environment flags to the qmake flags in case custom flags are needed
for CXXFLAGS, CFLAGS or LDFLAGS.

This allows for libraries to be linked even if they are not available systemwide

This was preventing me from building with Homebrew installed openSSL, which is not linked
to /user/local.

This has been tested on macOS 10.12, but not on linux or windows.