### PR TITLE
Install docs under shared/doc.

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -304,7 +304,7 @@ if (APPLE OR WIN32)
 else()
 	set (INSTALL_BIN 		${CMAKE_INSTALL_PREFIX}/bin)
 	set (INSTALL_SHARED 	${CMAKE_INSTALL_PREFIX}/share/)
-	set (INSTALL_DOC 		${INSTALL_SHARED}/faustlive/doc)
+	set (INSTALL_DOC 		${INSTALL_SHARED}/doc/faustlive)
 	set (INSTALL_ICONS 		${INSTALL_SHARED}/icons/hicolor)
 endif()
 


### PR DESCRIPTION
This is recommended for many linux distros, like [Arch Linux](https://wiki.archlinux.org/title/Arch_package_guidelines#Directories):
> `/usr/share/doc/{pkg}` | Application documentation

I wasn't sure whether I should open the PR towards `master` or `dev` but since master is the default branch I chose that...